### PR TITLE
Adds global memory coalescing to the naive algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Learning how to write a fast matmul kernel while in batch at the Recurse Center.

--- a/sgemm.cu
+++ b/sgemm.cu
@@ -11,14 +11,14 @@ const std::string errLogFile = "matrixMultiplicationMistake.txt";
 
 int main(int argc, char **argv) {
   if (argc != 2) {
-    std::cerr << "Select a kernel (range 0 - 1)" << std::endl;
+    std::cerr << "Select a kernel (range 0 - 3)" << std::endl;
     exit(EXIT_FAILURE);
   }
 
   // read kernel number
   int kernel_num = std::stoi(argv[1]);
-  if (kernel_num < 0 || kernel_num > 2) {
-    std::cerr << "Please enter a valid kernel number (0-1)" << std::endl;
+  if (kernel_num < 0 || kernel_num > 3) {
+    std::cerr << "Please enter a valid kernel number (0-2)" << std::endl;
     exit(EXIT_FAILURE);
   }
 
@@ -37,8 +37,8 @@ int main(int argc, char **argv) {
   cudaEventCreate(&beg);
   cudaEventCreate(&end);
 
-  std::vector<int> SIZE = {2, 4, 128,
-                           256}; // , 512, 1024, 2048, 4096, 8192, 16384};
+  std::vector<int> SIZE = {2,   4,    128, 256,
+                           512, 1024, 2048}; //, 4096}; // , 8192, 16384};
 
   long m, n, k, max_size;
   max_size = SIZE[SIZE.size() - 1];
@@ -132,8 +132,8 @@ int main(int argc, char **argv) {
       elapsed_time /= 1000.0; // convert ms to seconds
 
       long flops = 2 * k * m * n;
-      printf("Average elapsed time: (%8.6f) s, performance: (%8.1f) GFLOPS. "
-             "Size: (%ld).",
+      printf("Average elapsed time: (%8.6f) s, performance: (%4.1f) GFLOPS. "
+             "Size: (%ld).\n",
              elapsed_time / repeat_times,
              (flops * repeat_times) / (1e9 * elapsed_time), m);
       fflush(stdout);

--- a/src/kernels.cuh
+++ b/src/kernels.cuh
@@ -2,5 +2,6 @@
 #define KERNELS_CUH
 
 #include "kernels/1_naive.cuh"
+#include "kernels/2_global_memory_coalescing.cuh"
 
 #endif

--- a/src/kernels/2_global_memory_coalescing.cuh
+++ b/src/kernels/2_global_memory_coalescing.cuh
@@ -11,17 +11,15 @@ MxK * KxN = MxN
 __global__ void sgemm_global_memory_coalescing(int M, int N, int K, float alpha,
                                                const float *A, const float *B,
                                                float beta, float *C) {
-  const uint BLOCKSIZE = 32;
-  const uint x = blockIdx.x * BLOCKSIZE + (threadIdx.x / BLOCKSIZE);
-  const uint y = blockIdx.y * BLOCKSIZE + (threadIdx.x % BLOCKSIZE);
+  const uint x = blockIdx.x * blockDim.x + threadIdx.x;
+  const uint y = blockIdx.y * blockDim.y + threadIdx.y;
 
   if (x < M && y < N) {
     float tmp = 0.0;
     for (int i = 0; i < K; ++i) {
-      // tmp += A[y * K + i] * B[i * N + x]; // Corrected multiplication
-      tmp += A[x * K + i] * B[i * N + y]; // Corrected multiplication
+      tmp += A[y * K + i] * B[i * N + x]; // Corrected multiplication
     }
-    C[x * N + y] = alpha * tmp + beta * C[x * N + y];
+    C[y * N + x] = alpha * tmp + beta * C[y * N + x];
   }
 }
 

--- a/src/kernels/2_global_memory_coalescing.cuh
+++ b/src/kernels/2_global_memory_coalescing.cuh
@@ -1,0 +1,28 @@
+#ifndef GLOBAL_MEMORY_COALESCING_CUH
+#define GLOBAL_MEMORY_COALESCING_CUH
+
+#include <cstdio>
+#include <cuda_runtime.h>
+
+/*
+Naive Algorithm with an access pattern that supports global memory coalescing:
+MxK * KxN = MxN
+*/
+__global__ void sgemm_global_memory_coalescing(int M, int N, int K, float alpha,
+                                               const float *A, const float *B,
+                                               float beta, float *C) {
+  const uint BLOCKSIZE = 32;
+  const uint x = blockIdx.x * BLOCKSIZE + (threadIdx.x / BLOCKSIZE);
+  const uint y = blockIdx.y * BLOCKSIZE + (threadIdx.x % BLOCKSIZE);
+
+  if (x < M && y < N) {
+    float tmp = 0.0;
+    for (int i = 0; i < K; ++i) {
+      // tmp += A[y * K + i] * B[i * N + x]; // Corrected multiplication
+      tmp += A[x * K + i] * B[i * N + y]; // Corrected multiplication
+    }
+    C[x * N + y] = alpha * tmp + beta * C[x * N + y];
+  }
+}
+
+#endif

--- a/src/run_kernels.cu
+++ b/src/run_kernels.cu
@@ -98,6 +98,14 @@ void run_sgemm_naive(int M, int N, int K, float alpha, float *A, float *B,
   sgemm_naive<<<gridDim, blockDim>>>(M, N, K, alpha, A, B, beta, C);
 }
 
+void run_sgemm_global_memory_clsc(int M, int N, int K, float alpha, float *A,
+                                  float *B, float beta, float *C) {
+  dim3 gridDim(CEIL_DIV(M, 32), CEIL_DIV(N, 32));
+  dim3 blockDim(32 * 32);
+  sgemm_global_memory_coalescing<<<gridDim, blockDim>>>(M, N, K, alpha, A, B,
+                                                        beta, C);
+}
+
 void run_cublas_fp32(int M, int N, int K, float alpha, float *A, float *B,
                      float beta, float *C, cublasHandle_t handle) {
   // cuBLAS uses column-major order. So we change the order of our row-major A &
@@ -117,6 +125,9 @@ void run_kernel(int selected_kernel, int M, int N, int K, float alpha, float *A,
     break;
   case 1:
     run_sgemm_naive(M, N, K, alpha, A, B, beta, C);
+    break;
+  case 2:
+    run_sgemm_global_memory_clsc(M, N, K, alpha, A, B, beta, C);
     break;
   default:
     throw std::invalid_argument("Unknown kernel number");

--- a/src/run_kernels.cu
+++ b/src/run_kernels.cu
@@ -101,7 +101,7 @@ void run_sgemm_naive(int M, int N, int K, float alpha, float *A, float *B,
 void run_sgemm_global_memory_clsc(int M, int N, int K, float alpha, float *A,
                                   float *B, float beta, float *C) {
   dim3 gridDim(CEIL_DIV(M, 32), CEIL_DIV(N, 32));
-  dim3 blockDim(32 * 32);
+  dim3 blockDim(32, 32);
   sgemm_global_memory_coalescing<<<gridDim, blockDim>>>(M, N, K, alpha, A, B,
                                                         beta, C);
 }


### PR DESCRIPTION
Here we modify the naive algorithm's memory access pattern for the A, B and C matrices. We now ensure that threads that are on the same warp access global memory addresses that are close enough together that these accesses (each access is a 4B float) can be coalesced by the hardware into a few 32B load transactions. 

On the `4090` card we get 4500GFLOPS

```
Device ID: 0
      Name: NVIDIA GeForce RTX 4090
      Compute Capability: 8.9
      memoryBusWidth: 384
      maxThreadsPerBlock: 1024
      maxThreadsPerMultiProcessor: 1536
      maxRegsPerBlock: 65536
      maxRegsPerMultiProcessor: 65536
      totalGlobalMem: 24188MB
      sharedMemPerBlock: 48KB
      sharedMemPerMultiprocessor: 100KB
      totalConstMem: 64KB
      multiProcessorCount: 128
      Warp Size: 32
Max size: 2048
dimensions(m=n=k) 2, alpha: 0.6, beta: 4
Average elapsed time: (0.000002) s, performance: ( 0.0) GFLOPS. Size: (2).
dimensions(m=n=k) 4, alpha: 0.6, beta: 4
Average elapsed time: (0.000002) s, performance: ( 0.1) GFLOPS. Size: (4).
dimensions(m=n=k) 128, alpha: 0.6, beta: 4
Average elapsed time: (0.000009) s, performance: (489.6) GFLOPS. Size: (128).
dimensions(m=n=k) 256, alpha: 0.6, beta: 4
Average elapsed time: (0.000015) s, performance: (2177.6) GFLOPS. Size: (256).
dimensions(m=n=k) 512, alpha: 0.6, beta: 4
Average elapsed time: (0.000057) s, performance: (4696.7) GFLOPS. Size: (512).
dimensions(m=n=k) 1024, alpha: 0.6, beta: 4
Average elapsed time: (0.000484) s, performance: (4440.8) GFLOPS. Size: (1024).
dimensions(m=n=k) 2048, alpha: 0.6, beta: 4
Average elapsed time: (0.003805) s, performance: (4514.9) GFLOPS. Size: (2048).
```

however weirdly on the `1080` card we only get 53 GFLOPS

```Device ID: 0
      Name: NVIDIA GeForce GTX 1080 Ti
      Compute Capability: 6.1
      memoryBusWidth: 352
      maxThreadsPerBlock: 1024
      maxThreadsPerMultiProcessor: 2048
      maxRegsPerBlock: 65536
      maxRegsPerMultiProcessor: 65536
      totalGlobalMem: 11163MB
      sharedMemPerBlock: 48KB
      sharedMemPerMultiprocessor: 96KB
      totalConstMem: 64KB
      multiProcessorCount: 28
      Warp Size: 32
Max size: 2048
dimensions(m=n=k) 2, alpha: 0.6, beta: 4
Average elapsed time: (0.000006) s, performance: ( 0.0) GFLOPS. Size: (2).
dimensions(m=n=k) 4, alpha: 0.6, beta: 4
Average elapsed time: (0.000008) s, performance: ( 0.0) GFLOPS. Size: (4).
dimensions(m=n=k) 128, alpha: 0.6, beta: 4
Average elapsed time: (0.000177) s, performance: (23.6) GFLOPS. Size: (128).
dimensions(m=n=k) 256, alpha: 0.6, beta: 4
Average elapsed time: (0.001045) s, performance: (32.1) GFLOPS. Size: (256).
dimensions(m=n=k) 512, alpha: 0.6, beta: 4
Average elapsed time: (0.006137) s, performance: (43.7) GFLOPS. Size: (512).
dimensions(m=n=k) 1024, alpha: 0.6, beta: 4
Average elapsed time: (0.040023) s, performance: (53.7) GFLOPS. Size: (1024).
dimensions(m=n=k) 2048, alpha: 0.6, beta: 4
Average elapsed time: (0.318333) s, performance: (54.0) GFLOPS. Size: (2048).
```