### PR TITLE
Makes the 2D blocktiling somewhat agnostic to the sizes

### DIFF
--- a/sgemm.cu
+++ b/sgemm.cu
@@ -52,7 +52,9 @@ int main(int argc, char **argv)
   cudaEventCreate(&end);
 
   std::vector<int> SIZE = {128, 256,
-                           512, 1024, 2048}; // 4096}; // , 8192, 16384};
+                           512, 1024, 2048}; //4096};
+                           // at size 4096 we seem to run into floating point accuracy issues
+                           // and are not matching cublas
 
   long m, n, k, max_size;
   max_size = SIZE[SIZE.size() - 1];

--- a/src/kernels/6_shared_memory_2d_blocktiling.cuh
+++ b/src/kernels/6_shared_memory_2d_blocktiling.cuh
@@ -1,44 +1,59 @@
 #ifndef SHARED_MEMORY_2D_BLOCKTILING_CUH
 #define SHARED_MEMORY_2D_BLOCKTILING_CUH
 
+#include <cassert>
 #include <cstdio>
 #include <cuda_runtime.h>
 
 template <const uint BM, const uint BN, const uint BK, const uint TM, const uint TN>
 __global__ void sgemm_shared_memory_2d_blocktiling(int M, int N, int K, float alpha, const float *A, const float *B, float beta, float *C)
 {
+    // This is the size of the block that we are computing
+    const uint resultsFromBlocktile = BM * BN;
+    // Each thread computes TM*TN results so, how many threads do we need in this blocktile
+    // to compute all the elements?
+    const uint numThreadsBlocktile = resultsFromBlocktile / (TM * TN);
+    assert(numThreadsBlocktile == blockDim.x); // blockDim.x must be set up to be the right number of threads
     __shared__ float sA[BM * BK];
     __shared__ float sB[BK * BN];
-    float tmp[TM * TN] = {0.0};
+    float tmp[TM * TN] = {0.0}; // a thread's register cache
     // float sharedA_cache[TM] = {0.0};
     // float sharedB_cache[TM] = {0.0};
 
     const uint load_A_col = threadIdx.x % BK;
     const uint load_A_row = threadIdx.x / BK;
+    const uint strideA = numThreadsBlocktile / BK;
+    assert(((numThreadsBlocktile) % BK == 0)); // The total num of threads must be evenly divisible by BK
+                                   // so we can skip strideA complete rows while loading a tile.
+
     const uint load_B_col = threadIdx.x % BN;
-    // const uint load_B_row = threadIdx.x / BN;
-    // thread's position within an 8x8 grid
-    const uint thread_col = threadIdx.x % TN;
-    const uint thread_row = threadIdx.x / TM;
+    const uint load_B_row = threadIdx.x / BN;
+    const uint strideB = numThreadsBlocktile / BN;
+    assert((numThreadsBlocktile) % BN == 0);
+
+    // thread's position within an TMxTN grid
+    const uint thread_col = threadIdx.x % (BN / TN);
+    const uint thread_row = threadIdx.x / (BN / TN);
 
     // move A, B, C by the starting block
-    A += blockIdx.y * blockDim.x * K;
-    B += blockIdx.x * blockDim.x;
-    C += (blockIdx.y * blockDim.x * N) + (blockIdx.x * blockDim.x);
+    A += blockIdx.y * BM * K;
+    B += blockIdx.x * BN;
+    C += (blockIdx.y * BM * N) + (blockIdx.x * BN);
     for (int offset = 0; offset < K; offset += BK)
     {
-        for (int shiftA = 0; shiftA < 64; shiftA += 8)
+        for (int shiftA = 0; shiftA < BM; shiftA += strideA)
         {
             sA[((load_A_row + shiftA) * BK) + load_A_col] = A[((load_A_row + shiftA) * K) + load_A_col];
         }
-        for (int shiftB = 0; shiftB < BK; shiftB++)
+        for (int shiftB = 0; shiftB < BK; shiftB += strideB)
         {
-            sB[shiftB * BN + load_B_col] = B[shiftB * N + load_B_col];
+            sB[(load_B_row + shiftB) * BN + load_B_col] = B[(load_B_row + shiftB) * N + load_B_col];
         }
         __syncthreads();
         A += BK;
         B += BK * N;
-        #if 0
+#if 0
+        // This is currently not faster, investigating why.
         for (int idx = 0; idx < BK; idx++)
         {
             for (int r = 0; r < 8; r++)
@@ -62,28 +77,28 @@ __global__ void sgemm_shared_memory_2d_blocktiling(int M, int N, int K, float al
                 }
             }
         }
-        #endif
-        for (int r = 0; r < 8; r++)
+#endif
+        for (int r = 0; r < TM; r++)
         {
-            const uint c_row = thread_row * 8 + r;
-            for (int c = 0; c < 8; c++)
+            const uint c_row = thread_row * TM + r;
+            for (int c = 0; c < TN; c++)
             {
-                const uint c_col = thread_col * 8 + c;
+                const uint c_col = thread_col * TN + c;
                 for (int idx = 0; idx < BK; idx++)
                 {
-                    tmp[(r)*TM + c] += sA[c_row * BK + idx] * sB[idx * BN + c_col];
+                    tmp[(r)*TN + c] += sA[c_row * BK + idx] * sB[idx * BN + c_col];
                 }
             }
         }
         __syncthreads();
     }
-    for (int r = 0; r < 8; r++)
+    for (int r = 0; r < TM; r++)
     {
-        const uint c_row = thread_row * 8 + r;
-        for (int c = 0; c < 8; c++)
+        const uint c_row = thread_row * TM + r;
+        for (int c = 0; c < TN; c++)
         {
-            const uint c_col = thread_col * 8 + c;
-            C[c_row * N + c_col] = alpha * tmp[r * 8 + c] + beta * C[c_row * N + c_col];
+            const uint c_col = thread_col * TN + c;
+            C[c_row * N + c_col] = alpha * tmp[r * TN + c] + beta * C[c_row * N + c_col];
         }
     }
 }

--- a/src/run_kernels.cu
+++ b/src/run_kernels.cu
@@ -157,6 +157,7 @@ void run_sgemm_shared_memory_2d_blocktiling(int M, int N, int K, float alpha,
                                             float *C)
 {
   const uint BM = 128, BN = 128, BK = 8, TM = 8, TN = 8;
+  // const uint BM = 64, BN = 64, BK = 8, TM = 8, TN = 8;
 
   dim3 gridDim(CEIL_DIV(N, BN), CEIL_DIV(M, BM));
   dim3 blockDim((BM * BN) / (TM * TN));

--- a/src/run_kernels.cu
+++ b/src/run_kernels.cu
@@ -156,7 +156,7 @@ void run_sgemm_shared_memory_2d_blocktiling(int M, int N, int K, float alpha,
                                             float *A, float *B, float beta,
                                             float *C)
 {
-  const uint BM = 128, BN = 128, BK = 8, TM = 8, TN = 8;
+  const uint BM = 64, BN = 64, BK = 8, TM = 8, TN = 8;
 
   dim3 gridDim(CEIL_DIV(N, BN), CEIL_DIV(M, BM));
   dim3 blockDim((BM * BN) / (TM * TN));

--- a/src/run_kernels.cu
+++ b/src/run_kernels.cu
@@ -156,12 +156,13 @@ void run_sgemm_shared_memory_2d_blocktiling(int M, int N, int K, float alpha,
                                             float *A, float *B, float beta,
                                             float *C)
 {
-  const uint BLOCKSIDE = 64, BK = 8, TM = 8, TN = 8;
+  const uint BM = 128, BN = 128, BK = 8, TM = 8, TN = 8;
 
-  dim3 gridDim(CEIL_DIV(M, BLOCKSIDE), CEIL_DIV(N, BLOCKSIDE));
-  dim3 blockDim(TM * TN);
+  dim3 gridDim(CEIL_DIV(N, BN), CEIL_DIV(M, BM));
+  dim3 blockDim((BM * BN) / (TM * TN));
 
-  sgemm_shared_memory_2d_blocktiling<BLOCKSIDE, BLOCKSIDE, BK, TM, TN><<<gridDim, blockDim>>>(M, N, K, alpha, A, B, beta, C);
+  sgemm_shared_memory_2d_blocktiling<BM, BN, BK, TM, TN>
+      <<<gridDim, blockDim>>>(M, N, K, alpha, A, B, beta, C);
 }
 
 void run_cublas_fp32(int M, int N, int K, float alpha, float *A, float *B,

--- a/src/run_kernels.cu
+++ b/src/run_kernels.cu
@@ -156,7 +156,7 @@ void run_sgemm_shared_memory_2d_blocktiling(int M, int N, int K, float alpha,
                                             float *A, float *B, float beta,
                                             float *C)
 {
-  const uint BM = 64, BN = 64, BK = 8, TM = 8, TN = 8;
+  const uint BM = 128, BN = 128, BK = 8, TM = 8, TN = 8;
 
   dim3 gridDim(CEIL_DIV(N, BN), CEIL_DIV(M, BM));
   dim3 blockDim((BM * BN) / (TM * TN));


### PR DESCRIPTION
### Without the Register Caches for TM & TN:

BM = 128, BN = 128 as the blocktile size gives us worse performance on an RTX 4090 
`Average elapsed time: (0.000660) s, performance: (26034.3) GFLOPS. Size: (2048).`
vs
BM = 64, BN = 64
`Average elapsed time: (0.000621) s, performance: (27654.2) GFLOPS. Size: (2048).`

### With the Register Caches for TM & TN:
BM = 128, BN = 128 as the blocktile size gives us better performance on an RTX 4090
`Average elapsed time: (0.000587) s, performance: (29272.0) GFLOPS. Size: (2048).`
vs
BM = 64, BN = 64
`Average elapsed time: (0.000672) s, performance: (25554.3) GFLOPS. Size: (2048).`

![Screenshot 2025-03-12 at 11 08 44 AM](https://github.com/user-attachments/assets/41aff149-783c-4cff-a060-c756875ad9f1)